### PR TITLE
Fix breadcrumbs

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -87,7 +87,7 @@
     "globalMetadata": {
       "feedback_system": "Standard",
       "uhfHeaderId": "MSDocsHeader-AspNet",
-      "breadcrumb_path": "signalRbreadcrumb/toc.yml",
+      "breadcrumb_path": "/java/signalRbreadcrumb/json.yml",
       "ms.author":"riande"
     },
     "fileMetadata": {},

--- a/docfx.json
+++ b/docfx.json
@@ -87,7 +87,7 @@
     "globalMetadata": {
       "feedback_system": "Standard",
       "uhfHeaderId": "MSDocsHeader-AspNet",
-      "breadcrumb_path": "/java/signalRbreadcrumb/json.yml",
+      "breadcrumb_path": "/java/signalRbreadcrumb/toc.json",
       "ms.author":"riande"
     },
     "fileMetadata": {},

--- a/docfx.json
+++ b/docfx.json
@@ -31,7 +31,7 @@
       },
       {
         "files": [
-          "**/*.yml"
+          "**/toc.yml"
         ],
         "src": "signalRbreadcrumb",
         "dest": "signalRbreadcrumb",

--- a/signalRbreadcrumb/toc.yml
+++ b/signalRbreadcrumb/toc.yml
@@ -1,6 +1,12 @@
-- name: Docs
-  tocHref: /
-  topicHref: /
+- name: .NET
+  tocHref: /java/
+  topicHref: /dotnet/index
   items:
-
+  - name: ASP.NET Core
+    tocHref: /java/
+    topicHref: /aspnet/core/index
+    items:
+    - name: JAVA API browser
+      tocHref: /java/
+      topicHref: /java/api/index
 


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings and if PR Automerger service is available for this repo. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 